### PR TITLE
Fix failing ref to docstring

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,9 @@ makedocs(
         prettyurls = get(ENV, "CI", nothing) == "true"
     ),
 
+    # See https://github.com/jump-dev/JuMP.jl/issues/1576
+    strict = true,
+
     pages = [
         "Introduction" => "index.md",
     ]
@@ -15,4 +18,6 @@ makedocs(
 
 deploydocs(
     repo   = "github.com/JuliaAlgebra/TrigPolys.jl.git",
+
+    push_preview = true,
 )

--- a/src/TrigPolys.jl
+++ b/src/TrigPolys.jl
@@ -202,7 +202,7 @@ end
 """
     (p::TrigPoly)(x::Number)
 
-Evaluate `p(x)` at a single point. See [TrigPolys.evaluate](@red) for faster
+Evaluate `p(x)` at a single point. See [`TrigPolys.evaluate`](@ref) for faster
 evaluation for special points on the unit circle.
 """
 function (p::TrigPoly)(x::Number)


### PR DESCRIPTION
Also set `strict = true` so that the build fails in case of failures so that we get notified.